### PR TITLE
removing the unnecessary (and sometimes problematic) dependency pyqt5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ tqdm = "^4.65.0"
 pyqtgraph = "^0.13.3"
 tables = "^3.8.0"
 bokeh = "^3.2.1"
-pyqt5 = "^5.15.9"
 tensorflow = "2.13.0"
 napari = {extras = ["all"], version = "^0.4.18"}
 black = { version = "^23.7.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ptylab"
-version = "0.1.0"
+version = "0.1.1"
 description = "A cross-platform, open-source inverse modeling toolbox for conventional and Fourier ptychography"
 authors = ["Lars Loetgering <lars.loetgering@fulbrightmail.org>", "PtyLab Team"]
 license = "MIT"


### PR DESCRIPTION
This could be an important PR based on which OS you are using. `pyqt5` seems to have a different latest version based on the OS, which could create issues. I should not have specified `pyqt5` as a dependency because it is not a direct dependency that is being imported in the code structure. If any computer is missing this, it is better to be installed manually than to be defined in this project. Therefore, this PR removes it. 