### PR TITLE
visualisation and probe centering upon start

### DIFF
--- a/PtyLab/Engines/mPIE.py
+++ b/PtyLab/Engines/mPIE.py
@@ -93,7 +93,7 @@ class mPIE(BaseEngine):
 
         self.reconstruction.probeWindow = np.abs(self.reconstruction.probe)
 
-    def reconstruct(self, experimentalData=None, reconstruction=None):
+    def reconstruct(self, experimentalData=None, reconstruction=None, vis_after_each_iteration=None):
         """Reconstruct object. If experimentalData is given, it replaces the current data. Idem for reconstruction."""
 
         self.changeExperimentalData(experimentalData)
@@ -182,6 +182,9 @@ class mPIE(BaseEngine):
 
             # show reconstruction
             self.showReconstruction(loop)
+
+            if callable(vis_after_each_iteration):
+                vis_after_each_iteration(loop, self.reconstruction)
 
         if self.params.gpuFlag:
             self.logger.info("switch to cpu")

--- a/PtyLab/Monitor/Monitor.py
+++ b/PtyLab/Monitor/Monitor.py
@@ -270,6 +270,14 @@ class DummyMonitor(object):
     figureUpdateFrequency = 1000000
     verboseLevel = "low"
 
+    def update_encoder(self, *args, **kwargs):
+        pass
+
+    def updateBeamWidth(self, *args, **kwargs):
+        pass
+
+
+
     def updatePlot(self, object_estimate, probe_estimate):
         pass
 

--- a/PtyLab/Reconstruction/Reconstruction.py
+++ b/PtyLab/Reconstruction/Reconstruction.py
@@ -448,7 +448,7 @@ class Reconstruction(object):
                     f'Shape of saved probe cannot be extended to shape of required probe. File: {archive["object"].shape}. Need: {self.shape_O}'
                 )
 
-    def load_probe(self, filename, expand_npsm=False):
+    def load_probe(self, filename, expand_npsm=False, center_phase=False):
         """
         Load the probe from a previous reconstruction.
 
@@ -479,6 +479,17 @@ class Reconstruction(object):
                 raise RuntimeError(
                     f'Shape of saved probe cannot be extended to shape of required probe. File: {archive["probe"].shape}. Need: {self.shape_P}'
                 )
+        if center_phase:
+            self._center_probe_angle()
+
+    def _center_probe_angle(self):
+        """ Center the angle of propagation for the probe. """
+        from skimage.registration import phase_cross_correlation
+        from scipy.ndimage import fourier_shift
+        p0 = np.squeeze(self.probe)[0]
+        shift = phase_cross_correlation(p0, 0 * p0 + 1, normalization=None, space='fourier')[0]
+        phexp = np.fft.fftshift(fourier_shift(0 * p0 + 1j, -shift / 2))
+        self.probe *= phexp
 
     def load(self, filename):
         """Load the results given by saveResults."""


### PR DESCRIPTION
Two updates:

- small updates to the dummy monitor so that it works in practice (I think nobody has been using it). It mainly implements some empty methods that are called from mPIE.
- Add a callback option in mPIE.reconstruct, which is run after every iteration. In that way, if you do not use the normal monitor, you can for instance save a preview of your reconstruction to a folder. I found this to be quite useful for large reconstructions where otherwise the monitor would simply hang.

